### PR TITLE
Fix SpeedTrap script for Jordan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SpeedTrap
 ## What is it?
-Essentially SpeedTrap is a script that watches for FailRP and people going too fast on your server. From my research this does not exist anywhere else so I figured I'd be first. This is my first public release and I will be updating this a lot to fix all of the bugs that will be found. You can configure the speed before warning message and the actual warning message. This also works off of ace permissions so if you would like to allow someone to go over a certain speed you can do that as well or if you use `discord_perms` you can even use Discord role id's. ALSO you can give people an ace permission to be alerted when someone goes over said speed for over 6 seconds.
+Essentially SpeedTrap is a script that watches for FailRP and people going too fast on your server. From my research this does not exist anywhere else so I figured I'd be first. This is my first public release and I will be updating this a lot to fix all of the bugs that will be found. You can configure the speed before warning message and the actual warning message. This also works off of ace permissions so if you would like to allow someone to go over a certain speed you can do that as well.
 
 ## Permission Setup
 `add_ace group.member jordan.gofast allow` - Allowed to go over your set speed
@@ -8,20 +8,21 @@ Essentially SpeedTrap is a script that watches for FailRP and people going too f
 `add_ace group.staff jordan.gofastwatch allow` - See alerts for speed
 
 ## Configuration
-```------------------------------------------------------
+```------------------------------------------------------------
+-- Simple Whitelisted Speed Warning, Made By Jordan.#2139 --
+------------------------------------------------------------
+
+------------------------------------------------------
 -- CONFIG YOUR WARNING MESSAGE HERE WHEN GOING 150+ --
 --   CONFIG YOUR MAX ALLOWED SPEED BEFORE WARNING   --
 ------------------------------------------------------
 Config = {
-    warningmsg = "You Must Be Whitelisted To Go Over 150 MPH Please Slowdown Or An Admin Will Be Alerted!", -- Message
-    maxspeedwarning = 150 -- Speed Before Warning
-    }
+    warningmsg = "You Must Be Whitelisted To Go Over 150 MPH Please Slowdown Or An Admin Will Be Alerted!",
+    maxspeedwarning = 50,
+    StaffAlert = "^9[^7SpeedTrap^9] Player ^1{PLAYER} ^3is going over ^1{SPEED}",
+    StaffAlertCooldown = 60, -- How many seconds should cooldowns be for staff alert message?
+    debugEnabled = false,
+}
 --------------------------
 -- ^^^ DO THAT HERE ^^^ -- 
---------------------------
-
-
-discordRoleIds = {
-    "Role_ID",
-    "Role_ID"
-}```
+--------------------------```

--- a/client.lua
+++ b/client.lua
@@ -6,49 +6,57 @@
         -- DO NOT TOUCH THIS FILE OR YOU /WILL/ FUCK SHIT UP! EDIT THE CONFIG.LUA --
 -- DO NOT BE STUPID AND WHINE TO ME ABOUT THIS BEING BROKEN IF YOU TOUCHED THE LINES BELOW. --
 ----------------------------------------------------------------------------------------------
+debugEnabled = Config.debugEnabled;
+print("\n^7Simple Whitelisted Speed Warning | ^6 Made By Jordan.#2139^7")
 
 warnplayer = false;
 RegisterNetEvent('DoAllowSpeedClient')
 AddEventHandler('DoAllowSpeedClient', function()
-    print('yeet')
     warnplayer = true
+    if debugEnabled then 
+        print("[SpeedTrap Debug] DoAllowSpeedClient event ran...");
+    end
 end)
 
 warnplayer = false;
 RegisterNetEvent('AllowSpeedClient')
 AddEventHandler('AllowSpeedClient', function()
-    warnplayer = not warnplayer;
-    print('this is also gay but moreso because perms no worko')
+    warnplayer = false;
+    if debugEnabled then 
+        print("[SpeedTrap Debug] AllowSpeedClient event ran...");
+    end
 end)
 
 Citizen.CreateThread(function()
     while true do
-    Citizen.Wait(1)
-    
-    local player = GetPlayerPed(-1)
-    local veh = GetVehiclePedIsIn(player)
-    local mph = math.ceil(GetEntitySpeed(veh) * 2.23)
+        Citizen.Wait(1)
         
-    if warnplayer then
-        warn(Config.warningmsg)
-    end
+        local player = GetPlayerPed(-1)
+        local veh = GetVehiclePedIsIn(player)
+        local mph = math.ceil(GetEntitySpeed(veh) * 2.23)
+            
+        if warnplayer then
+            warn(Config.warningmsg)
+        end
 
-    if GetPedInVehicleSeat(veh, -1) == player then
-        if mph > Config.maxspeedwarning then
-            TriggerServerEvent('AllowSpeed')
-        else
-        warnplayer = false
+        if GetPedInVehicleSeat(veh, -1) == player then
+            if mph > Config.maxspeedwarning then
+                if not warningstring then 
+                    TriggerServerEvent('AllowSpeed')
+                end
+            else
+                warnplayer = false;
+                warningstring = false;
+            end
+        end
     end
-end
-end
 end)
 
 
 function warn(msg)
-warningstring = false
-	warningstring = msg
+	warningstring = true
 	PlaySoundFrontend(-1, "DELETE","HUD_DEATHMATCH_SOUNDSET", 1)
-	Citizen.Wait(6000)
+    Wait(3000);
 	warningstring = false
 end
 
@@ -59,17 +67,17 @@ function Initialize(scaleform)
     end
     PushScaleformMovieFunction(scaleform, "SHOW_SHARD_WASTED_MP_MESSAGE")
 	PushScaleformMovieFunctionParameterString("~r~WARNING!")
-    PushScaleformMovieFunctionParameterString(warningstring)
+    PushScaleformMovieFunctionParameterString(Config.warningmsg)
     PopScaleformMovieFunctionVoid()
     return scaleform
 end
 
 
 Citizen.CreateThread(function()
+    scaleform = Initialize("mp_big_message_freemode")
 while true do
 	Citizen.Wait(0)
     if warningstring then
-		scaleform = Initialize("mp_big_message_freemode")
 		DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255, 0)
     end
 end

--- a/config.lua
+++ b/config.lua
@@ -8,14 +8,11 @@
 ------------------------------------------------------
 Config = {
     warningmsg = "You Must Be Whitelisted To Go Over 150 MPH Please Slowdown Or An Admin Will Be Alerted!",
-    maxspeedwarning = 100
-    }
+    maxspeedwarning = 50,
+    StaffAlert = "^9[^7SpeedTrap^9] Player ^1{PLAYER} ^3is going over ^1{SPEED}",
+    StaffAlertCooldown = 60, -- How many seconds should cooldowns be for staff alert message?
+    debugEnabled = false,
+}
 --------------------------
 -- ^^^ DO THAT HERE ^^^ -- 
 --------------------------
-
-
-discordRoleIds = {
-    "Role_ID",
-    "Role_ID"
-}


### PR DESCRIPTION
+ Added Cooldown array in which makes it so staff will not get spammed with constant alerts in their chat...
+ Added Cooldown thread to decrease the cooldown's count for each different user breaking speed limit
+ Added more configuration options!
- Removed Discord Permissions as I didn't test to see if they had worked. If they worked in a previous version, then surely add them back to the code, apologies.